### PR TITLE
Direct linking to github editor for library.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Add new words
 
-It is simple, you need to access the `src/library.json`, add the new word and submit a pull request. 
+It is simple, you need to access the [`src/library.json`](https://github.com/LFeh/despolitizador/edit/master/src/library.json), add the new word and submit a pull request. 
 
 Example:
 


### PR DESCRIPTION
This proposal add a direct link to github's editor mode for `src/library.json`, so people can directly add more words