### PR TITLE
Adicionado testes para verificar integridade do método translate

### DIFF
--- a/src/js/__tests__/translator.js
+++ b/src/js/__tests__/translator.js
@@ -26,3 +26,17 @@ describe('translate', () => {
     expect(translate(library, inputText)).toBe('tomou de assalto');
   });
 });
+
+/*
+ * it fails on similar words like
+ * empregado and empregador
+ * regex catches the smaller one
+ */
+
+describe('check translate method integrity', () => {
+  Object.entries(library).forEach(([word, translation]) =>
+    test(`check word: ${word}`, () => {
+      expect(translate(library, word)).toBe(translation);
+    })
+  );
+});


### PR DESCRIPTION
No momento o método translate não traduz corretamente as palavras semelhantes.

Exemplo:
`empregado` e `empregador`.

Não consegui resolver o caso ainda porque não li todo o código! #desculpa 